### PR TITLE
Add raw payload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,8 @@ internals.Parser.prototype.parse = function (contentType) {
             return next();
         }
 
+        self.result.rawPayload = payload;
+
         internals.object(payload, self.result.contentType.mime, function (err, result) {
 
             if (err) {


### PR DESCRIPTION
Argumentation behind this change is that sometimes (literally in my case) we still need both unparsed and parsed body. In my case authorization scheme (Amazon AWSv4) needs raw body for signature check, but I still want it parsed afterwards to use useful hapi stuff like payload validation.