### PR TITLE
Don't catch synchronous handler errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -277,12 +277,15 @@ internals.object = function (payload, mime, next) {
 
 internals.jsonParse = function (payload, next) {
 
+    var parsed;
     try {
-        return next(null, JSON.parse(payload.toString('utf8')));
+        parsed = JSON.parse(payload.toString('utf8'));
     }
     catch (err) {
         return next(Boom.badRequest('Invalid request payload JSON format', err));
     }
+
+    return next(null, parsed);
 };
 
 


### PR DESCRIPTION
Previously, synchronous errors in the call stack of `next()` (including the route handler, in Hapi servers), were eaten by the try/catch and thrown as "invalid JSON payloads", even though they likely should have been treated as internal server errors.

I had difficulty writing a specific test case for this, but the fix does work in our application and does not break any other tests.