### PR TITLE
Added support for brotli compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ node_js:
 
 sudo: false
 
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const Content = require('content');
 const Hoek = require('hoek');
 const Pez = require('pez');
 const Wreck = require('wreck');
-
+const decompressStream = require('iltorb').decompressStream;
 
 // Declare internals
 
@@ -82,7 +82,7 @@ internals.Parser.prototype.read = function () {
         return this.parse(contentType);
     }
 
-    // Parse: false, 'gunzip'
+    // Parse: false, 'gunzip', 'br'
 
     return this.raw();
 };
@@ -98,8 +98,8 @@ internals.Parser.prototype.parse = function (contentType) {
     // Content-encoding
 
     const contentEncoding = source.headers['content-encoding'];
-    if (contentEncoding === 'gzip' || contentEncoding === 'deflate') {
-        const decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : Zlib.createInflate());
+    if (contentEncoding === 'gzip' || contentEncoding === 'deflate' || contentEncoding === 'br') {
+        const decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : (contentEncoding === 'br' ? decompressStream() : Zlib.createInflate()));
         next = Hoek.once(next);                                                                     // Modify next() for async events
         this.next = next;
         decoder.once('error', (err) => {
@@ -176,10 +176,10 @@ internals.Parser.prototype.raw = function () {
 
     // Content-encoding
 
-    if (this.settings.parse === 'gunzip') {
+    if (this.settings.parse === 'gunzip' || this.settings.parse === 'br') {
         const contentEncoding = source.headers['content-encoding'];
-        if (contentEncoding === 'gzip' || contentEncoding === 'deflate') {
-            const decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : Zlib.createInflate());
+        if (contentEncoding === 'gzip' || contentEncoding === 'deflate' || contentEncoding === 'br') {
+            const decoder = (contentEncoding === 'gzip' ? Zlib.createGunzip() : (contentEncoding === 'br' ? decompressStream() : Zlib.createInflate()));
             next = Hoek.once(next);                                                                     // Modify next() for async events
 
             decoder.once('error', (err) => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "boom": "3.x.x",
     "content": "3.x.x",
     "hoek": "4.x.x",
+    "iltorb": "^1.0.9",
     "pez": "2.x.x",
     "wreck": "7.x.x"
   },


### PR DESCRIPTION
Added support for brotli compression. The required changes to inert and hapi have also been done and the PRs submitted for merging.

This PR implements the following: https://github.com/hapijs/hapi/issues/3037