### PR TITLE
Node 4.3.1 or higer is required for proper multipart parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "multipart"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.3.1"
   },
   "dependencies": {
     "boom": "3.x.x",


### PR DESCRIPTION
Until Node commit https://github.com/nodejs/node/pull/4738 Buffer.byteLength function did not work correctly. (This commit was entered in Node 4.3.1 https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#4.3.1)
On hapijs/pez project, the commit https://github.com/hapijs/pez/commit/9f0042b9460714da54f5fbdd3dc6d979ce1c2b69#diff-6d186b954a58d5bb740f73d84fe39073R162 was depending on Buffer.byteLength to work correctly.
This resulted in a misbehaving multipart parsing when the payload maxBytes is close to the uploaded binary file (Inside the multipart form post payload).
Meaning that Subtext library parsing a multipart payload with a binary file that its content-length is smaller than the maxBytes parameter but is close enough that the inner hapijs/pez libary will count mistakenly for a bigger buffer size and will return an error "Maximum size exceeded" https://github.com/hapijs/pez/blob/master/lib/index.js#L163 (Subtext will return "Invalid multipart payload format" https://github.com/hapijs/subtext/blob/master/lib/index.js#L301).

I attached a little program that will help you understand the described scenario. (example.zip)
Notice: 
1. You need to put a binary file inside the project for the program to work.
2. In my example the file was 28MB and the limit I entered was 30MB.

[example.zip](https://github.com/hapijs/subtext/files/308163/example.zip)