### PR TITLE
Add keepFailedJsonString setting

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,3 +16,4 @@ Parses the request body and exposes it in a callback.
 - `uploads`: string, directory for file uploads
 - `decoders`: an object mapping content-encoding names to their corresponding decoder functions
 - `compression`: an object mapping content-encoding names to their corresponding options passed to the `decoders` functions
+- `keepFailedJsonString`: boolean, true to keep failed parsed json string assuming it can be encoded to utf8. false by default.

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,9 @@ internals.Parser.prototype.parse = function (contentType) {
         internals.object(payload, this.result.contentType.mime, (err, result) => {
 
             if (err) {
+                if (this.settings.keepFailedJsonString) {
+                    this.result.failedJsonString = result;
+                }
                 this.result.payload = null;
                 return next(err);
             }
@@ -279,12 +282,15 @@ internals.jsonParse = function (payload, next) {
         return next(null, null);
     }
 
+    let rawPayload;
     let parsed;
+
     try {
-        parsed = JSON.parse(payload.toString('utf8'));
+        rawPayload = payload.toString('utf8');
+        parsed = JSON.parse(rawPayload);
     }
     catch (err) {
-        return next(Boom.badRequest('Invalid request payload JSON format', err));
+        return next(Boom.badRequest('Invalid request payload JSON format', err), rawPayload);
     }
 
     return next(null, parsed);

--- a/test/index.js
+++ b/test/index.js
@@ -240,6 +240,39 @@ describe('parse()', () => {
         });
     });
 
+    it('errors on invalid JSON payload and returns failedJsonString with setting failedPayloadJsonString:true', (done) => {
+
+        const payload = '{"x":"1","y":"2","z":"3"';
+        const request = Wreck.toReadableStream(payload);
+        request.headers = {
+            'content-type': 'application/json'
+        };
+
+        Subtext.parse(request, null, { parse: true, output: 'data', keepFailedJsonString: true }, (err, parsed) => {
+
+            expect(err).to.exist();
+            expect(parsed.failedJsonString).to.exist();
+            expect(parsed.failedJsonString).to.equal(payload);
+            done();
+        });
+    });
+
+    it('errors on invalid JSON payload and does not return string with setting failedPayloadJsonString:false', (done) => {
+
+        const payload = '{"x":"1","y":"2","z":"3"';
+        const request = Wreck.toReadableStream(payload);
+        request.headers = {
+            'content-type': 'application/json'
+        };
+
+        Subtext.parse(request, null, { parse: true, output: 'data', keepFailedJsonString: false }, (err, parsed) => {
+
+            expect(err).to.exist();
+            expect(parsed.failedJsonString).to.not.exist();
+            done();
+        });
+    });
+
     it('peeks at the unparsed stream of a parsed body', (done) => {
 
         const payload = '{"x":"1","y":"2","z":"3"}';


### PR DESCRIPTION
I need the ability to process invalid json parsed to Hapi, instead of ignoring / logging it.  

This is the first part of that work.

I have added a setting `keepFailedJsonString` that if true will keep the failed string in the result object, as `failedJsonString`