### PR TITLE
Allow for configuration of maximum number of form variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,12 @@ internals.Parser.prototype.parse = function (contentType) {
             return next(err);
         }
 
-        internals.object(payload, this.result.contentType.mime, (err, result) => {
+        const settings = {
+            mime : this.result.contentType.mime,
+            maxKeys : this.settings.maxKeys
+        };
+
+        internals.object(payload, settings, (err, result) => {
 
             if (err) {
                 this.result.payload = null;
@@ -243,7 +248,10 @@ internals.Parser.prototype.raw = function () {
 };
 
 
-internals.object = function (payload, mime, next) {
+internals.object = function (payload, settings, next) {
+
+    const mime = settings.mime;
+    const maxKeys = settings.maxKeys;
 
     // Binary
 
@@ -266,7 +274,7 @@ internals.object = function (payload, mime, next) {
     // Form-encoded
 
     if (mime === 'application/x-www-form-urlencoded') {
-        return next(null, payload.length ? Querystring.parse(payload.toString('utf8')) : {});
+        return next(null, payload.length ? Querystring.parse(payload.toString('utf8'), '&', '=', { maxKeys }) : {});
     }
 
     return next(Boom.unsupportedMediaType());
@@ -410,7 +418,7 @@ internals.Parser.prototype.multipart = function (source, contentType) {
                     return annotate({});
                 }
 
-                internals.object(payload, mime, (err, result) => annotate(err ? payload : result));
+                internals.object(payload, { mime }, (err, result) => annotate(err ? payload : result));
             });
         }
     };

--- a/test/index.js
+++ b/test/index.js
@@ -591,6 +591,50 @@ describe('parse()', () => {
         });
     });
 
+    it('parses when maxKeys is not provided', (done) => {
+
+        let payload = 'x0=a';
+
+        for (let i = 1; i < 10000; ++i) {
+            payload += '&x' + i + '=a';
+        }
+
+        const request = Wreck.toReadableStream(payload);
+        request.headers = {
+            'content-type': 'application/x-www-form-urlencoded'
+        };
+
+        Subtext.parse(request, null, { parse: true, output: 'data' }, (err, parsed) => {
+
+            expect(err).to.not.exist();
+            expect(parsed.mime).to.equal('application/x-www-form-urlencoded');
+            expect(Object.keys(parsed.payload).length).to.equal(1000);
+            done();
+        });
+    });
+
+    it('parses large form encoded payload with maxKeys', (done) => {
+
+        let payload = 'x0=a';
+
+        for (let i = 1; i < 10000; ++i) {
+            payload += '&x' + i + '=a';
+        }
+
+        const request = Wreck.toReadableStream(payload);
+        request.headers = {
+            'content-type': 'application/x-www-form-urlencoded'
+        };
+
+        Subtext.parse(request, null, { parse: true, output: 'data', maxKeys: 15000 }, (err, parsed) => {
+
+            expect(err).to.not.exist();
+            expect(parsed.mime).to.equal('application/x-www-form-urlencoded');
+            expect(Object.keys(parsed.payload).length).to.equal(10000);
+            done();
+        });
+    });
+
     it('errors on malformed zipped payload', (done) => {
 
         const payload = '7d8d78347h8347d58w347hd58w374d58w37h5d8w37hd4';


### PR DESCRIPTION
Currently there is no configuration option between subtext and querystring regarding the maxKeys it can process. In some cases this causes data to be silently truncated resulting in headaches and confusion :p 

Ideally it would be great to throw an exception when this occurs but querystring doesn't currently provide this feedback. This will at least make it configurable.