### PR TITLE
Fix stream error propagation for node v16+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -396,7 +396,7 @@ internals.pipe = function (from, to) {
 
     const forwardError = (err) => {
 
-        unpipe(from, to);
+        unpipe();
         to.emit('error', err);
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@ const Wreck = require('@hapi/wreck');
 
 
 const internals = {
-    kSubtext: Symbol('subtext'),
     decoders: {
         gzip: (options) => Zlib.createGunzip(options),
         deflate: (options) => Zlib.createInflate(options)
@@ -79,7 +78,7 @@ internals.parse = async function (req, tap, options, contentType) {
     // Tap request
 
     if (tap) {
-        source = internals.pipe(source, tap);
+        [source] = internals.pipe(source, tap);
     }
 
     // Multipart
@@ -133,7 +132,9 @@ internals.decoder = function (source, options) {
         return orig.call(stream, event, ...args);
     };
 
-    return internals.pipe(source, stream);
+    [source] = internals.pipe(source, stream);
+
+    return source;
 };
 
 
@@ -151,7 +152,7 @@ internals.raw = async function (req, tap, options) {
     // Setup source
 
     if (tap) {
-        source = internals.pipe(source, tap);
+        [source] = internals.pipe(source, tap);
     }
 
     // Output: 'stream'
@@ -316,8 +317,8 @@ internals.writeFile = function (req, options, stream) {
             file.removeListener('error', finalize);
 
             if (err) {
-                internals.unpipe(stream, counter);
-                internals.unpipe(counter, file);
+                unpipeStreamToCounter();
+                unpipeCounterToFile();
 
                 file.destroy();
                 Fs.unlink(path, (/* fsErr */) => reject(err));      // Ignore unlink errors
@@ -346,8 +347,8 @@ internals.writeFile = function (req, options, stream) {
         const onAbort = () => finalize(Boom.badRequest('Client connection aborted'));
         req.once('aborted', onAbort);
 
-        internals.pipe(stream, counter);
-        internals.pipe(counter, file);
+        const [, unpipeStreamToCounter] = internals.pipe(stream, counter);
+        const [, unpipeCounterToFile] = internals.pipe(counter, file);
     });
 
     promise.catch(Hoek.ignore);     // Prevent triggering node's PromiseRejectionHandledWarning
@@ -393,29 +394,21 @@ internals.part = async function (part, output, set, options) {
 
 internals.pipe = function (from, to) {
 
-    Hoek.assert(!from[internals.kSubtext], 'Piping/unpiping only supports one consuming stream per producing stream.');
-
     const forwardError = (err) => {
 
-        internals.unpipe(from, to);
+        unpipe(from, to);
         to.emit('error', err);
     };
 
-    from[internals.kSubtext] = { forwardError };
+    const unpipe = () => {
+
+        from.removeListener('error', forwardError);
+        return from.unpipe(to);
+    };
+
     from.once('error', forwardError);
 
-    return from.pipe(to);
-};
-
-internals.unpipe = function (from, to) {
-
-    if (from[internals.kSubtext]) {
-        const { forwardError } = from[internals.kSubtext];
-        from.removeListener('error', forwardError);
-        from[internals.kSubtext] = null;
-    }
-
-    return from.unpipe(to);
+    return [from.pipe(to), unpipe];
 };
 
 internals.Counter = class extends Stream.Transform {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ const Wreck = require('@hapi/wreck');
 
 
 const internals = {
+    kSubtext: Symbol('subtext'),
     decoders: {
         gzip: (options) => Zlib.createGunzip(options),
         deflate: (options) => Zlib.createInflate(options)
@@ -315,8 +316,8 @@ internals.writeFile = function (req, options, stream) {
             file.removeListener('error', finalize);
 
             if (err) {
-                stream.unpipe(counter);
-                counter.unpipe(file);
+                internals.unpipe(stream, counter);
+                internals.unpipe(counter, file);
 
                 file.destroy();
                 Fs.unlink(path, (/* fsErr */) => reject(err));      // Ignore unlink errors
@@ -392,15 +393,30 @@ internals.part = async function (part, output, set, options) {
 
 internals.pipe = function (from, to) {
 
-    from.once('error', (err) => {
+    Hoek.assert(!from[internals.kSubtext], 'Piping/unpiping only supports one consuming stream per producing stream.');
 
-        from.unpipe(to);
+    const forwardError = (err) => {
+
+        internals.unpipe(from, to);
         to.emit('error', err);
-    });
+    };
+
+    from[internals.kSubtext] = { forwardError };
+    from.once('error', forwardError);
 
     return from.pipe(to);
 };
 
+internals.unpipe = function (from, to) {
+
+    if (from[internals.kSubtext]) {
+        const { forwardError } = from[internals.kSubtext];
+        from.removeListener('error', forwardError);
+        from[internals.kSubtext] = null;
+    }
+
+    return from.unpipe(to);
+};
 
 internals.Counter = class extends Stream.Transform {
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
+    "@hapi/eslint-plugin": "5.x.x",
     "@hapi/lab": "24.x.x",
     "form-data": "3.x.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1263,7 +1263,7 @@ describe('parse()', () => {
         req.abort();
 
         const incoming = await receive;
-        await expect(Subtext.parse(incoming, null, { parse: false, output: 'file', uploads: path })).to.reject();
+        await expect(Subtext.parse(incoming, null, { parse: false, output: 'file', uploads: path })).to.reject(/Client connection aborted/);
         expect(Fs.readdirSync(path).length).to.equal(count);
     });
 


### PR DESCRIPTION
There was a failing test for node v16+.  The issue is that starting in node v16, when a request is aborted it will not only emit an aborted event, but also an error event on `req`.  That error event would propagate to other streams due to subtext's stream error propagation, and eventually surface as a separate error.  The fix here is to remove the stream error propagation when handling the abort, by not only unpiping the streams, but also removing the error handlers that were setup while piping.