### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -5,23 +5,10 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
-
-    runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: install
-        run: npm install
-      - name: test
-        run: npm test
+    uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2019, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2019, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ const Wreck = require('@hapi/wreck');
 
 
 const internals = {
+    kSubtext: Symbol('subtext'),
     decoders: {
         gzip: (options) => Zlib.createGunzip(options),
         deflate: (options) => Zlib.createInflate(options)
@@ -315,8 +316,8 @@ internals.writeFile = function (req, options, stream) {
             file.removeListener('error', finalize);
 
             if (err) {
-                stream.unpipe(counter);
-                counter.unpipe(file);
+                internals.unpipe(stream, counter);
+                internals.unpipe(counter, file);
 
                 file.destroy();
                 Fs.unlink(path, (/* fsErr */) => reject(err));      // Ignore unlink errors
@@ -392,15 +393,30 @@ internals.part = async function (part, output, set, options) {
 
 internals.pipe = function (from, to) {
 
-    from.once('error', (err) => {
+    Hoek.assert(!from[internals.kSubtext], 'Piping/unpiping only supports one consuming stream per producing stream.');
 
-        from.unpipe(to);
+    const forwardError = (err) => {
+
+        internals.unpipe(from, to);
         to.emit('error', err);
-    });
+    };
+
+    from[internals.kSubtext] = { forwardError };
+    from.once('error', forwardError);
 
     return from.pipe(to);
 };
 
+internals.unpipe = function (from, to) {
+
+    if (from[internals.kSubtext]) {
+        const { forwardError } = from[internals.kSubtext];
+        from.removeListener('error', forwardError);
+        from[internals.kSubtext] = null;
+    }
+
+    return from.unpipe(to);
+};
 
 internals.Counter = class extends Stream.Transform {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,12 +115,12 @@ internals.parse = async function (req, tap, options, contentType) {
 internals.decoder = function (source, options) {
 
     const contentEncoding = source.headers['content-encoding'];
-    const decoders = options.decoders || internals.decoders;
+    const decoders = options.decoders ?? internals.decoders;
     if (!decoders.hasOwnProperty(contentEncoding)) {
         return source;
     }
 
-    const decoderOptions = options.compression && options.compression[contentEncoding] || null;
+    const decoderOptions = options.compression?.[contentEncoding] ?? null;
     const stream = decoders[contentEncoding](decoderOptions);
 
     const orig = stream.emit;
@@ -207,7 +207,7 @@ internals.object = function (options, payload, mime) {
     // Form-encoded
 
     if (mime === 'application/x-www-form-urlencoded') {
-        const parse = options.querystring || Querystring.parse;
+        const parse = options.querystring ?? Querystring.parse;
         return payload.length ? parse(payload.toString('utf8')) : {};
     }
 
@@ -305,7 +305,7 @@ internals.writeFile = function (req, options, stream) {
 
     const promise = new Promise((resolve, reject) => {
 
-        const path = File.uniqueFilename(options.uploads || Os.tmpdir());
+        const path = File.uniqueFilename(options.uploads ?? Os.tmpdir());
         const file = Fs.createWriteStream(path, { flags: 'wx' });
         const counter = new internals.Counter(options);
 

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bourne": "2.x.x",
-    "@hapi/content": "^5.0.2",
-    "@hapi/file": "2.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/pez": "^5.0.1",
-    "@hapi/wreck": "17.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/content": "^6.0.0",
+    "@hapi/file": "^2.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/pez": "^6.0.0",
+    "@hapi/wreck": "^18.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "5.x.x",
-    "@hapi/lab": "24.x.x",
-    "form-data": "3.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "*",
+    "@hapi/lab": "^25.0.1",
+    "form-data": "^4.0.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
+    "@hapi/eslint-plugin": "5.x.x",
     "@hapi/lab": "24.x.x",
     "form-data": "3.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@hapi/boom": "^10.0.0",
     "@hapi/bourne": "^3.0.0",
     "@hapi/content": "^6.0.0",
-    "@hapi/file": "^2.0.0",
+    "@hapi/file": "^3.0.0",
     "@hapi/hoek": "^10.0.0",
     "@hapi/pez": "^6.0.0",
     "@hapi/wreck": "^18.0.0"

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Subtext;
+
+    before(async () => {
+
+        Subtext = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Subtext)).to.equal([
+            'default',
+            'parse'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1263,7 +1263,7 @@ describe('parse()', () => {
         req.abort();
 
         const incoming = await receive;
-        await expect(Subtext.parse(incoming, null, { parse: false, output: 'file', uploads: path })).to.reject();
+        await expect(Subtext.parse(incoming, null, { parse: false, output: 'file', uploads: path })).to.reject(/Client connection aborted/);
         expect(Fs.readdirSync(path).length).to.equal(count);
     });
 


### PR DESCRIPTION
 - Test on node v14+, adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as subtext v8.  Note that this is based on #96 which should be published in v7.