### PR TITLE
Respond with error for unhandled content encodings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,8 +117,12 @@ internals.decoder = function (source, options) {
 
     const contentEncoding = source.headers['content-encoding'];
     const decoders = options.decoders ?? internals.decoders;
-    if (!decoders.hasOwnProperty(contentEncoding)) {
+    if (contentEncoding === undefined) {
         return source;
+    }
+
+    if (!decoders.hasOwnProperty(contentEncoding)) {
+        throw Boom.unsupportedMediaType();
     }
 
     const decoderOptions = options.compression?.[contentEncoding] ?? null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,9 @@ internals.decoder = function (source, options) {
     }
 
     if (!decoders.hasOwnProperty(contentEncoding)) {
-        throw Boom.unsupportedMediaType();
+        const error = Boom.unsupportedMediaType();
+        error.output.headers = { 'accept-encoding': [...Reflect.ownKeys(decoders), 'identity'].join(', ') };
+        throw error;
     }
 
     const decoderOptions = options.compression?.[contentEncoding] ?? null;

--- a/test/index.js
+++ b/test/index.js
@@ -622,7 +622,7 @@ describe('parse()', () => {
         expect(payload.toString()).to.equal(body);
     });
 
-    it('leaves payload raw when encoding unknown', async () => {
+    it('errors when encoding unknown', async () => {
 
         const body = '{"x":"1","y":"2","z":"3"}';
         const compressed = await internals.compress('gzip', body);
@@ -632,8 +632,8 @@ describe('parse()', () => {
             'content-type': 'application/json'
         };
 
-        const { payload } = await Subtext.parse(request, null, { parse: 'gunzip', output: 'data' });
-        expect(payload.toString()).to.equal(compressed.toString());
+        const err = await expect(Subtext.parse(request, null, { parse: 'gunzip', output: 'data' })).to.reject('Unsupported Media Type');
+        expect(err.output.statusCode).to.equal(415);
     });
 
     it('unzips payload without parsing (external decoders)', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -634,6 +634,9 @@ describe('parse()', () => {
 
         const err = await expect(Subtext.parse(request, null, { parse: 'gunzip', output: 'data' })).to.reject('Unsupported Media Type');
         expect(err.output.statusCode).to.equal(415);
+        expect(err.output.headers).to.include({
+            'accept-encoding': 'gzip, deflate, identity'
+        });
     });
 
     it('unzips payload without parsing (external decoders)', async () => {


### PR DESCRIPTION
This seems to be a more appropriate response.

Link: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/415