### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hapi/subtext",
   "description": "HTTP payload parsing",
   "version": "8.1.3",
-  "repository": "git://github.com/hapijs/subtext",
+  "repository": "https://github.com/hapijs/subtext",
   "main": "lib/index.js",
   "files": [
     "lib"


### PR DESCRIPTION
## Summary
- update the package repository URL to use HTTPS instead of the legacy git protocol

## Validation
- git diff --check
- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'